### PR TITLE
Add LightInject.

### DIFF
--- a/src/DependencyInjectorBenchmarks.Tests/ContainerTests.cs
+++ b/src/DependencyInjectorBenchmarks.Tests/ContainerTests.cs
@@ -21,6 +21,7 @@ namespace DependencyInjectorBenchmarks.Tests
             Assert.NotNull(CastleWindsorBenchmark.Instance.ResolveSingleton());
             Assert.NotNull(AutofacBenchmark.Instance.ResolveSingleton());
             Assert.NotNull(UnityBenchmarks.Instance.ResolveSingleton());
+            Assert.NotNull(LightInjectBenchmark.Instance.ResolveSingleton());
 
             Assert.Same(DirectBenchmark.Instance.ResolveSingleton(), DirectBenchmark.Instance.ResolveSingleton());
             Assert.Same(Mef2Benchmark.Instance.ResolveSingleton(), Mef2Benchmark.Instance.ResolveSingleton());
@@ -30,6 +31,7 @@ namespace DependencyInjectorBenchmarks.Tests
             Assert.Same(CastleWindsorBenchmark.Instance.ResolveSingleton(), CastleWindsorBenchmark.Instance.ResolveSingleton());
             Assert.Same(AutofacBenchmark.Instance.ResolveSingleton(), AutofacBenchmark.Instance.ResolveSingleton());
             Assert.Same(UnityBenchmarks.Instance.ResolveSingleton(), UnityBenchmarks.Instance.ResolveSingleton());
+            Assert.Same(LightInjectBenchmark.Instance.ResolveSingleton(), LightInjectBenchmark.Instance.ResolveSingleton());
         }
 
         [Fact]
@@ -43,6 +45,7 @@ namespace DependencyInjectorBenchmarks.Tests
             Assert.NotNull(CastleWindsorBenchmark.Instance.ResolveTransient());
             Assert.NotNull(AutofacBenchmark.Instance.ResolveTransient());
             Assert.NotNull(UnityBenchmarks.Instance.ResolveTransient());
+            Assert.NotNull(LightInjectBenchmark.Instance.ResolveTransient());
 
             Assert.NotSame(DirectBenchmark.Instance.ResolveTransient(), DirectBenchmark.Instance.ResolveTransient());
             Assert.NotSame(Mef2Benchmark.Instance.ResolveTransient(), Mef2Benchmark.Instance.ResolveTransient());
@@ -52,6 +55,7 @@ namespace DependencyInjectorBenchmarks.Tests
             Assert.NotSame(CastleWindsorBenchmark.Instance.ResolveTransient(), CastleWindsorBenchmark.Instance.ResolveTransient());
             Assert.NotSame(AutofacBenchmark.Instance.ResolveTransient(), AutofacBenchmark.Instance.ResolveTransient());
             Assert.NotSame(UnityBenchmarks.Instance.ResolveTransient(), UnityBenchmarks.Instance.ResolveTransient());
+            Assert.NotSame(LightInjectBenchmark.Instance.ResolveTransient(), LightInjectBenchmark.Instance.ResolveTransient());
         }
 
         [Fact]
@@ -65,6 +69,7 @@ namespace DependencyInjectorBenchmarks.Tests
             Assert.NotNull(CastleWindsorBenchmark.Instance.ResolveCombined());
             Assert.NotNull(AutofacBenchmark.Instance.ResolveCombined());
             Assert.NotNull(UnityBenchmarks.Instance.ResolveCombined());
+            Assert.NotNull(LightInjectBenchmark.Instance.ResolveCombined());
 
             Assert.NotSame(DirectBenchmark.Instance.ResolveCombined(), DirectBenchmark.Instance.ResolveCombined());
             Assert.NotSame(Mef2Benchmark.Instance.ResolveCombined(), Mef2Benchmark.Instance.ResolveCombined());
@@ -74,6 +79,7 @@ namespace DependencyInjectorBenchmarks.Tests
             Assert.NotSame(CastleWindsorBenchmark.Instance.ResolveCombined(), CastleWindsorBenchmark.Instance.ResolveCombined());
             Assert.NotSame(AutofacBenchmark.Instance.ResolveCombined(), AutofacBenchmark.Instance.ResolveCombined());
             Assert.NotSame(UnityBenchmarks.Instance.ResolveCombined(), UnityBenchmarks.Instance.ResolveCombined());
+            Assert.NotSame(LightInjectBenchmark.Instance.ResolveCombined(), LightInjectBenchmark.Instance.ResolveCombined());
         }
     }
 }

--- a/src/DependencyInjectorBenchmarks/CombinedBenchmark.cs
+++ b/src/DependencyInjectorBenchmarks/CombinedBenchmark.cs
@@ -30,5 +30,8 @@ namespace DependencyInjectorBenchmarks
 
         [Benchmark]
         public ICombined Unity() => UnityBenchmarks.Instance.ResolveCombined();
+
+        [Benchmark]
+        public ICombined LightInject() => LightInjectBenchmark.Instance.ResolveCombined();
     }
 }

--- a/src/DependencyInjectorBenchmarks/Containers/LightinjectBenchmark.cs
+++ b/src/DependencyInjectorBenchmarks/Containers/LightinjectBenchmark.cs
@@ -1,0 +1,26 @@
+﻿using LightInject;
+using DependencyInjectorBenchmarks.Scenarios;
+
+namespace DependencyInjectorBenchmarks.Containers
+{
+    public class LightInjectBenchmark : IContainerBenchmark
+    {
+        public static readonly LightInjectBenchmark Instance = new LightInjectBenchmark();
+
+        private readonly IServiceContainer container;
+
+        public LightInjectBenchmark()
+        {
+            this.container = new ServiceContainer();
+            this.container.Register<ISingleton, Singleton>(new PerContainerLifetime());
+            this.container.Register<ITransient, Transient>(new PerRequestLifeTime());
+            this.container.Register<ICombined, Combined>(new PerRequestLifeTime());
+        }
+
+        public ISingleton ResolveSingleton() => this.container.GetInstance<ISingleton>();
+
+        public ITransient ResolveTransient() => this.container.GetInstance<ITransient>();
+
+        public ICombined ResolveCombined() => this.container.GetInstance<ICombined>();
+    }
+}

--- a/src/DependencyInjectorBenchmarks/Containers/LightinjectBenchmark.cs
+++ b/src/DependencyInjectorBenchmarks/Containers/LightinjectBenchmark.cs
@@ -13,8 +13,8 @@ namespace DependencyInjectorBenchmarks.Containers
         {
             this.container = new ServiceContainer();
             this.container.Register<ISingleton, Singleton>(new PerContainerLifetime());
-            this.container.Register<ITransient, Transient>(new PerRequestLifeTime());
-            this.container.Register<ICombined, Combined>(new PerRequestLifeTime());
+            this.container.Register<ITransient, Transient>();
+            this.container.Register<ICombined, Combined>();
         }
 
         public ISingleton ResolveSingleton() => this.container.GetInstance<ISingleton>();

--- a/src/DependencyInjectorBenchmarks/DependencyInjectorBenchmarks.csproj
+++ b/src/DependencyInjectorBenchmarks/DependencyInjectorBenchmarks.csproj
@@ -56,6 +56,10 @@
       <HintPath>..\packages\Castle.Windsor.3.3.0\lib\net45\Castle.Windsor.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="LightInject, Version=4.0.9.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\LightInject.4.0.9\lib\net46\LightInject.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.Diagnostics.Tracing.TraceEvent, Version=1.0.41.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.41\lib\net40\Microsoft.Diagnostics.Tracing.TraceEvent.dll</HintPath>
@@ -133,6 +137,9 @@
       <DependentUpon>IContainerBenchmark.cs</DependentUpon>
     </Compile>
     <Compile Include="Containers\IContainerBenchmark.cs" />
+    <Compile Include="Containers\LightinjectBenchmark.cs">
+      <DependentUpon>IContainerBenchmark.cs</DependentUpon>
+    </Compile>
     <Compile Include="Containers\Mef2Benchmark.cs">
       <DependentUpon>IContainerBenchmark.cs</DependentUpon>
     </Compile>
@@ -145,7 +152,9 @@
     <Compile Include="Containers\SimpleInjectorBenchmark.cs">
       <DependentUpon>IContainerBenchmark.cs</DependentUpon>
     </Compile>
-    <Compile Include="Containers\UnityBenchmarks.cs" />
+    <Compile Include="Containers\UnityBenchmarks.cs">
+      <DependentUpon>IContainerBenchmark.cs</DependentUpon>
+    </Compile>
     <Compile Include="Scenarios\Combined.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -166,7 +175,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.41\build\Microsoft.Diagnostics.Tracing.TraceEvent.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.41\build\Microsoft.Diagnostics.Tracing.TraceEvent.targets'))" />
   </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/src/DependencyInjectorBenchmarks/SingletonBenchmark.cs
+++ b/src/DependencyInjectorBenchmarks/SingletonBenchmark.cs
@@ -30,5 +30,8 @@ namespace DependencyInjectorBenchmarks
 
         [Benchmark]
         public ISingleton Unity() => UnityBenchmarks.Instance.ResolveSingleton();
+
+        [Benchmark]
+        public ISingleton LightInject() => LightInjectBenchmark.Instance.ResolveSingleton();
     }
 }

--- a/src/DependencyInjectorBenchmarks/TransientBenchmark.cs
+++ b/src/DependencyInjectorBenchmarks/TransientBenchmark.cs
@@ -35,5 +35,8 @@ namespace DependencyInjectorBenchmarks
 
         [Benchmark]
         public ITransient Unity() => UnityBenchmarks.Instance.ResolveTransient();
+
+        [Benchmark]
+        public ITransient LightInject() => LightInjectBenchmark.Instance.ResolveTransient();
     }
 }

--- a/src/DependencyInjectorBenchmarks/packages.config
+++ b/src/DependencyInjectorBenchmarks/packages.config
@@ -6,6 +6,7 @@
   <package id="Castle.Core" version="3.3.0" targetFramework="net46" />
   <package id="Castle.Windsor" version="3.3.0" targetFramework="net46" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net46" />
+  <package id="LightInject" version="4.0.9" targetFramework="net46" />
   <package id="Microsoft.Composition" version="1.0.30" targetFramework="net46" />
   <package id="Microsoft.Diagnostics.Tracing.TraceEvent" version="1.0.41" targetFramework="net46" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net46" />


### PR DESCRIPTION
See [seesharper/lightinject](https://github.com/seesharper/LightInject). 

Results: 

```
BenchmarkDotNet=v0.9.6.0
OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i7-4790K CPU @ 4.00GHz, ProcessorCount=8
Frequency=3903995 ticks, Resolution=256.1479 ns, Timer=TSC
HostCLR=MS.NET 4.0.30319.42000, Arch=32-bit RELEASE
JitModules=clrjit-v4.6.1569.0

Type=SingletonBenchmark  Mode=Throughput  Platform=X64
Jit=RyuJit

         Method |        Median |      StdDev |   Scaled |    Gen 0 | Gen 1 | Gen 2 | Bytes Allocated/Op |
--------------- |-------------- |------------ |--------- |--------- |------ |------ |------------------- |
         Direct |     0.2560 ns |   0.0750 ns |     1.00 |        - |     - |     - |               0,00 |
 SimpleInjector |    28.1208 ns |   0.8211 ns |   109.84 |        - |     - |     - |               0,00 |
            Mef | 1,087.3723 ns |  89.3543 ns | 4,247.19 |   340,79 |     - |     - |             200,18 |
        Ninject | 2,535.1148 ns | 184.6381 ns | 9,901.96 | 1 712,00 |     - |     - |             989,98 |
           Mef2 |   105.0260 ns |   5.0071 ns |   410.22 |    95,98 |     - |     - |              55,22 |
  CastleWindsor |   251.4759 ns |  14.0589 ns |   982.25 |   271,25 |     - |     - |             157,90 |
        Autofac |   337.8870 ns |  18.4791 ns | 1,319.76 |   485,42 |     - |     - |             280,94 |
          Unity |   587.8877 ns |  37.0150 ns | 2,296.24 |   395,85 |     - |     - |             228,24 |
    LightInject |    34.8816 ns |   1.8856 ns |   136.24 |        - |     - |     - |               0,00 |

Type=TransientBenchmark  Mode=Throughput  Platform=X64
Jit=RyuJit

         Method |        Median |      StdDev |   Scaled |  Gen 0 |  Gen 1 | Gen 2 | Bytes Allocated/Op |
--------------- |-------------- |------------ |--------- |------- |------- |------ |------------------- |
         Direct |     2.1539 ns |   0.1999 ns |     1.00 |   3,78 |      - |     - |              10,82 |
 SimpleInjector |    31.3550 ns |   3.0449 ns |    14.56 |   3,64 |      - |     - |              10,40 |
            Mef | 3,738.4482 ns | 134.1653 ns | 1,735.64 | 287,16 |      - |     - |             836,10 |
        Ninject | 6,402.8906 ns | 206.5255 ns | 2,972.65 | 459,00 | 133,00 |     - |           1 720,90 |
           Mef2 |   101.7612 ns |   4.4281 ns |    47.24 |  16,17 |      - |     - |              46,30 |
  CastleWindsor |   814.1233 ns |  33.0398 ns |   377.97 | 124,24 |      - |     - |             360,63 |
        Autofac |   712.8212 ns |  70.2080 ns |   330.94 | 164,06 |      - |     - |             469,88 |
          Unity |   884.1957 ns |  22.7797 ns |   410.50 |  75,85 |      - |     - |             221,92 |
    LightInject |    78.2070 ns |   3.0507 ns |    36.31 |   3,52 |      - |     - |              10,09 |

Type=CombinedBenchmark  Mode=Throughput  Platform=X64
Jit=RyuJit

         Method |         Median |      StdDev |   Scaled |  Gen 0 |  Gen 1 | Gen 2 | Bytes Allocated/Op |
--------------- |--------------- |------------ |--------- |------- |------- |------ |------------------- |
         Direct |      9.2318 ns |   0.3818 ns |     1.00 |   4,05 |      - |     - |              22,23 |
 SimpleInjector |     43.9669 ns |   2.8253 ns |     4.76 |   3,79 |      - |     - |              20,79 |
            Mef | 10,160.1934 ns | 660.5598 ns | 1,100.56 | 362,65 |  10,15 |     - |           2 078,67 |
        Ninject | 18,625.7679 ns | 650.3172 ns | 2,017.56 | 703,00 | 225,00 |     - |           5 234,37 |
           Mef2 |    145.9288 ns |   9.3776 ns |    15.81 |  14,02 |      - |     - |              76,79 |
  CastleWindsor |  2,690.9186 ns |  87.8795 ns |   291.48 | 143,16 |      - |     - |             800,58 |
        Autofac |  2,184.3117 ns |  84.9548 ns |   236.61 | 253,23 |      - |     - |           1 399,98 |
          Unity |  2,355.7730 ns | 130.2586 ns |   255.18 |  92,26 |      - |     - |             507,59 |
    LightInject |    133.1260 ns |  11.7193 ns |    14.42 |   4,46 |      - |     - |              24,50 |
```

cc @seesharper 