### PR TITLE
Add DryIoc

### DIFF
--- a/src/DependencyInjectorBenchmarks.Tests/ContainerTests.cs
+++ b/src/DependencyInjectorBenchmarks.Tests/ContainerTests.cs
@@ -22,6 +22,7 @@ namespace DependencyInjectorBenchmarks.Tests
             Assert.IsNotNull(LightInjectBenchmark.Instance.ResolveSingleton());
             Assert.IsNotNull(StructureMapBenchmark.Instance.ResolveSingleton());
             Assert.IsNotNull(FsContainerBenchmark.Instance.ResolveSingleton());
+            Assert.IsNotNull(DryIocBenchmark.Instance.ResolveSingleton());
 
             Assert.AreSame(DirectBenchmark.Instance.ResolveSingleton(), DirectBenchmark.Instance.ResolveSingleton());
             Assert.AreSame(NinjectBenchmark.Instance.ResolveSingleton(), NinjectBenchmark.Instance.ResolveSingleton());
@@ -31,6 +32,7 @@ namespace DependencyInjectorBenchmarks.Tests
             Assert.AreSame(LightInjectBenchmark.Instance.ResolveSingleton(), LightInjectBenchmark.Instance.ResolveSingleton());
             Assert.AreSame(StructureMapBenchmark.Instance.ResolveSingleton(), StructureMapBenchmark.Instance.ResolveSingleton());
             Assert.AreSame(FsContainerBenchmark.Instance.ResolveSingleton(), FsContainerBenchmark.Instance.ResolveSingleton());
+            Assert.AreSame(DryIocBenchmark.Instance.ResolveSingleton(), DryIocBenchmark.Instance.ResolveSingleton());
         }
 
         [TestMethod]
@@ -44,6 +46,7 @@ namespace DependencyInjectorBenchmarks.Tests
             Assert.IsNotNull(LightInjectBenchmark.Instance.ResolveTransient());
             Assert.IsNotNull(StructureMapBenchmark.Instance.ResolveTransient());
             Assert.IsNotNull(FsContainerBenchmark.Instance.ResolveTransient());
+            Assert.IsNotNull(DryIocBenchmark.Instance.ResolveTransient());
 
             Assert.AreNotSame(DirectBenchmark.Instance.ResolveTransient(), DirectBenchmark.Instance.ResolveTransient());
             Assert.AreNotSame(NinjectBenchmark.Instance.ResolveTransient(), NinjectBenchmark.Instance.ResolveTransient());
@@ -53,6 +56,7 @@ namespace DependencyInjectorBenchmarks.Tests
             Assert.AreNotSame(LightInjectBenchmark.Instance.ResolveTransient(), LightInjectBenchmark.Instance.ResolveTransient());
             Assert.AreNotSame(StructureMapBenchmark.Instance.ResolveTransient(), StructureMapBenchmark.Instance.ResolveTransient());
             Assert.AreNotSame(FsContainerBenchmark.Instance.ResolveTransient(), FsContainerBenchmark.Instance.ResolveTransient());
+            Assert.AreNotSame(DryIocBenchmark.Instance.ResolveTransient(), DryIocBenchmark.Instance.ResolveTransient());
         }
 
         [TestMethod]
@@ -66,6 +70,7 @@ namespace DependencyInjectorBenchmarks.Tests
             Assert.IsNotNull(LightInjectBenchmark.Instance.ResolveCombined());
             Assert.IsNotNull(StructureMapBenchmark.Instance.ResolveCombined());
             Assert.IsNotNull(FsContainerBenchmark.Instance.ResolveCombined());
+            Assert.IsNotNull(DryIocBenchmark.Instance.ResolveCombined());
 
             Assert.AreNotSame(DirectBenchmark.Instance.ResolveCombined(), DirectBenchmark.Instance.ResolveCombined());
             Assert.AreNotSame(NinjectBenchmark.Instance.ResolveCombined(), NinjectBenchmark.Instance.ResolveCombined());
@@ -75,6 +80,7 @@ namespace DependencyInjectorBenchmarks.Tests
             Assert.AreNotSame(LightInjectBenchmark.Instance.ResolveCombined(), LightInjectBenchmark.Instance.ResolveCombined());
             Assert.AreNotSame(StructureMapBenchmark.Instance.ResolveCombined(), StructureMapBenchmark.Instance.ResolveCombined());
             Assert.AreNotSame(FsContainerBenchmark.Instance.ResolveCombined(), FsContainerBenchmark.Instance.ResolveCombined());
+            Assert.AreNotSame(DryIocBenchmark.Instance.ResolveCombined(), DryIocBenchmark.Instance.ResolveCombined());
         }
     }
 }

--- a/src/DependencyInjectorBenchmarks/CombinedBenchmark.cs
+++ b/src/DependencyInjectorBenchmarks/CombinedBenchmark.cs
@@ -32,5 +32,8 @@ namespace DependencyInjectorBenchmarks
 
         [Benchmark]
         public ICombined FsContainer() => FsContainerBenchmark.Instance.ResolveCombined();
+
+        [Benchmark]
+        public ICombined DryIoc() => DryIocBenchmark.Instance.ResolveCombined();
     }
 }

--- a/src/DependencyInjectorBenchmarks/Containers/DryIocBenchmark.cs
+++ b/src/DependencyInjectorBenchmarks/Containers/DryIocBenchmark.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using DependencyInjectorBenchmarks.Scenarios;
+using DryIoc;
+
+namespace DependencyInjectorBenchmarks.Containers
+{
+    public class DryIocBenchmark : IContainerBenchmark
+    {
+        public static readonly DryIocBenchmark Instance = new DryIocBenchmark();
+
+        private Container container;
+
+        public DryIocBenchmark()
+        {
+            container = new Container();
+
+            container.Register<ISingleton>(Reuse.Singleton, Made.Of(() => Singleton.Instance));
+            container.Register<ITransient, Transient>();
+            container.Register<ICombined, Combined>();
+        }
+
+        public ICombined ResolveCombined()
+            => container.Resolve<ICombined>();
+
+        public ISingleton ResolveSingleton()
+            => container.Resolve<ISingleton>();
+
+        public ITransient ResolveTransient()
+            => container.Resolve<ITransient>();
+    }
+}

--- a/src/DependencyInjectorBenchmarks/DependencyInjectorBenchmarks.csproj
+++ b/src/DependencyInjectorBenchmarks/DependencyInjectorBenchmarks.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.10.8" />
+    <PackageReference Include="DryIoc.dll" Version="2.11.3" />
     <PackageReference Include="fs.container.core" Version="1.2.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
     <PackageReference Include="Autofac" Version="4.6.0" />

--- a/src/DependencyInjectorBenchmarks/SingletonBenchmark.cs
+++ b/src/DependencyInjectorBenchmarks/SingletonBenchmark.cs
@@ -32,5 +32,8 @@ namespace DependencyInjectorBenchmarks
 
         [Benchmark]
         public ISingleton FsContainer() => FsContainerBenchmark.Instance.ResolveSingleton();
+
+        [Benchmark]
+        public ISingleton DryIoc() => DryIocBenchmark.Instance.ResolveSingleton();
     }
 }

--- a/src/DependencyInjectorBenchmarks/TransientBenchmark.cs
+++ b/src/DependencyInjectorBenchmarks/TransientBenchmark.cs
@@ -32,5 +32,8 @@ namespace DependencyInjectorBenchmarks
 
         [Benchmark]
         public ITransient FsContainer() => FsContainerBenchmark.Instance.ResolveTransient();
+
+        [Benchmark]
+        public ITransient DryIoc() => DryIocBenchmark.Instance.ResolveTransient();
     }
 }


### PR DESCRIPTION
I add [DryIoc](https://bitbucket.org/dadhi/dryioc) container.
Results:
```
BenchmarkDotNet=v0.10.8, OS=Windows 10 Redstone 2 (10.0.15063)
Processor=Intel Core i5-5200U CPU 2.20GHz (Broadwell), ProcessorCount=4
Frequency=2143472 Hz, Resolution=466.5328 ns, Timer=TSC
dotnet cli version=1.0.4
  [Host]    : .NET Core 4.6.25211.01, 64bit RyuJIT
  RyuJitX64 : .NET Core 4.6.25211.01, 64bit RyuJIT

Job=RyuJitX64  Jit=RyuJit  Platform=X64

Singletone

         Method |         Mean |      Error |     StdDev | Scaled | ScaledSD |  Gen 0 | Allocated |
--------------- |-------------:|-----------:|-----------:|-------:|---------:|-------:|----------:|
         Direct |     5.579 ns |  0.0454 ns |  0.0270 ns |   1.00 |     0.00 |      - |       0 B |
         DryIoc |    19.423 ns |  0.1970 ns |  0.1747 ns |   3.48 |     0.03 |      - |       0 B |
    LightInject |    32.735 ns |  0.3533 ns |  0.3305 ns |   5.87 |     0.06 |      - |       0 B |
 SimpleInjector |    45.772 ns |  0.4189 ns |  0.3918 ns |   8.21 |     0.08 |      - |       0 B |
     AspNetCore |    62.235 ns |  0.6607 ns |  0.6180 ns |  11.16 |     0.12 |      - |       0 B |
    FsContainer |   270.120 ns |  2.9885 ns |  2.7954 ns |  48.42 |     0.53 | 0.1268 |     200 B |
        Autofac |   575.121 ns |  6.4953 ns |  6.0757 ns | 103.10 |     1.15 | 0.4063 |     640 B |
   StructureMap |   758.056 ns |  5.4475 ns |  4.8290 ns | 135.89 |     1.04 | 0.7114 |    1120 B |
        Ninject | 1,600.301 ns | 17.7352 ns | 16.5896 ns | 286.87 |     3.16 | 0.6752 |    1064 B |

Transient

         Method |         Mean |       Error |      StdDev |       Median | Scaled | ScaledSD |  Gen 0 |  Gen 1 |  Gen 2 | Allocated |
--------------- |-------------:|------------:|------------:|-------------:|-------:|---------:|-------:|-------:|-------:|----------:|
         Direct |     6.057 ns |   0.2754 ns |   0.7207 ns |     5.861 ns |   1.00 |     0.00 | 0.0152 |      - |      - |      24 B |
         DryIoc |    23.976 ns |   0.3527 ns |   0.3299 ns |    24.006 ns |   4.01 |     0.43 | 0.0152 |      - |      - |      24 B |
    LightInject |    38.114 ns |   0.4895 ns |   0.4579 ns |    38.208 ns |   6.37 |     0.68 | 0.0152 |      - |      - |      24 B |
 SimpleInjector |    58.130 ns |   2.9062 ns |   8.1971 ns |    54.349 ns |   9.72 |     1.72 | 0.0152 |      - |      - |      24 B |
     AspNetCore |    74.698 ns |   0.7237 ns |   0.6770 ns |    74.758 ns |  12.49 |     1.34 | 0.0151 |      - |      - |      24 B |
    FsContainer |   696.516 ns |  10.6421 ns |   9.4340 ns |   697.623 ns | 116.45 |    12.51 | 0.2079 |      - |      - |     328 B |
        Autofac |   732.660 ns |  17.9262 ns |  16.7681 ns |   728.535 ns | 122.50 |    13.34 | 0.4778 |      - |      - |     752 B |
   StructureMap |   953.493 ns |   8.3453 ns |   7.8062 ns |   955.448 ns | 159.42 |    17.04 | 0.6542 |      - |      - |    1032 B |
        Ninject | 5,711.716 ns | 220.0379 ns | 624.2109 ns | 5,688.391 ns | 954.97 |   145.81 | 1.2820 | 0.3131 | 0.0002 |    2038 B |

Combined

         Method |         Mean |       Error |        StdDev | Scaled | ScaledSD |  Gen 0 |  Gen 1 |  Gen 2 | Allocated |
--------------- |-------------:|------------:|--------------:|-------:|---------:|-------:|-------:|-------:|----------:|
         Direct |     20.98 ns |   0.2491 ns |     0.2330 ns |   1.00 |     0.00 | 0.0356 |      - |      - |      56 B |
         DryIoc |     39.49 ns |   0.4693 ns |     0.4390 ns |   1.88 |     0.03 | 0.0356 |      - |      - |      56 B |
    LightInject |     50.04 ns |   0.4250 ns |     0.3767 ns |   2.39 |     0.03 | 0.0356 |      - |      - |      56 B |
 SimpleInjector |     64.30 ns |   0.6675 ns |     0.6244 ns |   3.06 |     0.04 | 0.0355 |      - |      - |      56 B |
     AspNetCore |     98.19 ns |   1.1287 ns |     1.0005 ns |   4.68 |     0.07 | 0.0355 |      - |      - |      56 B |
    FsContainer |  1,689.53 ns |  16.9127 ns |    15.8201 ns |  80.53 |     1.13 | 0.4921 |      - |      - |     776 B |
        Autofac |  1,975.64 ns |  22.2294 ns |    20.7934 ns |  94.17 |     1.39 | 1.1482 |      - |      - |    1808 B |
   StructureMap |  2,324.80 ns |  22.5480 ns |    21.0914 ns | 110.81 |     1.53 | 1.2589 |      - |      - |    1984 B |
        Ninject | 14,117.21 ns | 444.5890 ns | 1,282.7409 ns | 672.87 |    61.25 | 3.5870 | 0.8861 | 0.0012 |    5675 B |




```





